### PR TITLE
Simplify the command to switch between Java versions

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -47,19 +47,5 @@ function clean-git-branches() {
   ~/.config/scripts/clean-branches.sh
 }
 
-# Method to switch between OpenJDK versions
-function openjdk() {
-  if [ -z "$1" ]; then
-    echo "Usage: openjdk <version>"
-    return 1
-  fi
-
-  if [ -d "/opt/homebrew/opt/openjdk@$1" ]; then
-    export JAVA_HOME="/opt/homebrew/opt/openjdk@$1"
-    export PATH="$JAVA_HOME/bin:$PATH"
-    echo "Switched to OpenJDK $1"
-  else
-    echo "OpenJDK $1 is not installed. Available versions:"
-    ls -1 /opt/homebrew/opt | grep openjdk@
-  fi
-}
+# Source the new openjdk.sh script file
+source ~/.config/scripts/openjdk.sh

--- a/openjdk.sh
+++ b/openjdk.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+function openjdk() {
+  if [ -z "$1" ]; then
+    echo "Usage: openjdk <version>"
+    return 1
+  fi
+
+  if [ -d "/opt/homebrew/opt/openjdk@$1" ]; then
+    export JAVA_HOME="/opt/homebrew/opt/openjdk@$1"
+    export PATH="$JAVA_HOME/bin:$PATH"
+    echo "Switched to OpenJDK $1"
+  else
+    echo "OpenJDK $1 is not installed. Available versions:"
+    ls -1 /opt/homebrew/opt | grep openjdk@
+  fi
+}

--- a/save-config.sh
+++ b/save-config.sh
@@ -5,3 +5,6 @@ cp ./clean-branches.sh ~/.config/scripts/clean-branches.sh
 
 # Write the ./.zshrc file to the right location
 cp ./.zshrc ~/.zshrc
+
+# Write the ./openjdk.sh file to the right location
+cp ./openjdk.sh ~/.config/scripts/openjdk.sh


### PR DESCRIPTION
Add a new script to simplify switching between Java versions.

* **openjdk.sh**
  - Create a new script file to switch between OpenJDK versions.
  - Define a function `openjdk` to switch between OpenJDK versions.
  - Check if the version argument is provided, if not, print usage.
  - Check if the specified OpenJDK version is installed, if not, list available versions.
  - If the specified OpenJDK version is installed, update `JAVA_HOME` and `PATH` environment variables.

* **.zshrc**
  - Remove the existing `openjdk` function definition.
  - Source the new `openjdk.sh` script file.

* **save-config.sh**
  - Add a line to copy the new `openjdk.sh` file to the right location.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mischag01/zsh-config/pull/1?shareId=72e13322-5fcb-4bb1-88f2-d82d3049b091).